### PR TITLE
Updated names for mmWave entities

### DIFF
--- a/zhaquirks/inovelli/VZM32SN.py
+++ b/zhaquirks/inovelli/VZM32SN.py
@@ -192,7 +192,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_room_size_preset",
-        fallback_name="MMWave room size preset",
+        fallback_name="mmWave room size preset",
     )
     .number(
         "light_on_presence_behavior",
@@ -349,7 +349,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_z_min",
-        fallback_name="MMWave Z min boundary",
+        fallback_name="mmWave Height Minimum (Floor)",
     )
     .number(
         "mmwave_z_max",
@@ -359,7 +359,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_z_max",
-        fallback_name="MMWave Z max boundary",
+        fallback_name="mmWave Height Maximum (Ceiling)",
     )
     .number(
         "mmwave_x_min",
@@ -369,7 +369,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_x_min",
-        fallback_name="MMWave X min boundary",
+        fallback_name="mmWave Width Minimum (Left)",
     )
     .number(
         "mmwave_x_max",
@@ -379,7 +379,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_x_max",
-        fallback_name="MMWave X max boundary",
+        fallback_name="mmWave Width Maximum (Right)",
     )
     .number(
         "mmwave_y_min",
@@ -389,7 +389,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_y_min",
-        fallback_name="MMWave Y min boundary",
+        fallback_name="mmWave Depth Minimum (Near)",
     )
     .number(
         "mmwave_y_max",
@@ -399,7 +399,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_y_max",
-        fallback_name="MMWave Y max boundary",
+        fallback_name="mmWave Depth Maximum (Far)",
     )
     .number(
         "mmwave_detect_sensitivity",
@@ -409,7 +409,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_detect_sensitivity",
-        fallback_name="MMWave detect sensitivity",
+        fallback_name="mmWave detect sensitivity",
     )
     .number(
         "mmwave_detect_trigger",
@@ -419,7 +419,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_detect_trigger",
-        fallback_name="MMWave detect trigger",
+        fallback_name="mmWave detect trigger",
     )
     .number(
         "mmwave_hold_time",
@@ -429,7 +429,7 @@ MMWAVE_CLUSTER_ID = 0xFC32
         step=1,
         entity_type=EntityType.CONFIG,
         translation_key="mmwave_hold_time",
-        fallback_name="MMWave hold time",
+        fallback_name="mmWave hold time",
     )
     .add_to_registry()
 )

--- a/zhaquirks/inovelli/VZM32SN.py
+++ b/zhaquirks/inovelli/VZM32SN.py
@@ -342,63 +342,63 @@ MMWAVE_CLUSTER_ID = 0xFC32
     )
     # MMWave cluster entities
     .number(
-        "mmwave_z_min",
+        "mmwave_height_minimum_floor",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_z_min",
+        translation_key="mmwave_height_minimum_floor",
         fallback_name="mmWave Height Minimum (Floor)",
     )
     .number(
-        "mmwave_z_max",
+        "mmwave_height_maximum_ceiling",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_z_max",
+        translation_key="mmwave_height_maximum_ceiling",
         fallback_name="mmWave Height Maximum (Ceiling)",
     )
     .number(
-        "mmwave_x_min",
+        "mmwave_width_minimum_left",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_x_min",
+        translation_key="mmwave_width_minimum_left",
         fallback_name="mmWave Width Minimum (Left)",
     )
     .number(
-        "mmwave_x_max",
+        "mmwave_width_maximum_right",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_x_max",
+        translation_key="mmwave_width_maximum_right",
         fallback_name="mmWave Width Maximum (Right)",
     )
     .number(
-        "mmwave_y_min",
+        "mmwave_depth_minimum_near",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_y_min",
+        translation_key="mmwave_depth_minimum_near",
         fallback_name="mmWave Depth Minimum (Near)",
     )
     .number(
-        "mmwave_y_max",
+        "mmwave_depth_maximum_far",
         MMWAVE_CLUSTER_ID,
         min_value=-32768,
         max_value=32767,
         step=1,
         entity_type=EntityType.CONFIG,
-        translation_key="mmwave_y_max",
+        translation_key="mmwave_depth_maximum_far",
         fallback_name="mmWave Depth Maximum (Far)",
     )
     .number(

--- a/zhaquirks/inovelli/__init__.py
+++ b/zhaquirks/inovelli/__init__.py
@@ -1286,32 +1286,32 @@ class InovelliVZM32SNMMWaveCluster(CustomCluster):
     class AttributeDefs(BaseAttributeDefs):
         """Attribute definitions."""
 
-        mmwave_z_min = ZCLAttributeDef(
+        mmwave_height_minimum_floor = ZCLAttributeDef(
             id=0x0065,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
-        mmwave_z_max = ZCLAttributeDef(
+        mmwave_height_maximum_ceiling = ZCLAttributeDef(
             id=0x0066,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
-        mmwave_x_min = ZCLAttributeDef(
+        mmwave_width_minimum_left = ZCLAttributeDef(
             id=0x0067,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
-        mmwave_x_max = ZCLAttributeDef(
+        mmwave_width_maximum_right = ZCLAttributeDef(
             id=0x0068,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
-        mmwave_y_min = ZCLAttributeDef(
+        mmwave_depth_minimum_near = ZCLAttributeDef(
             id=0x0069,
             type=t.int16s,
             is_manufacturer_specific=True,
         )
-        mmwave_y_max = ZCLAttributeDef(
+        mmwave_depth_maximum_far = ZCLAttributeDef(
             id=0x006A,
             type=t.int16s,
             is_manufacturer_specific=True,


### PR DESCRIPTION
Updated entity names for mmWave to be more user friendly and align with the Z-Wave switch.

## Proposed change
Updated entity names for mmWave to be more user friendly and align with the Z-Wave switch.


## Additional information
Updated strings to match Red Series


## Device diagnostics
N/A. String changes only.


## Checklist
- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
