### PR TITLE
Added missing entity for stay life

### DIFF
--- a/zhaquirks/inovelli/VZM32SN.py
+++ b/zhaquirks/inovelli/VZM32SN.py
@@ -411,6 +411,16 @@ MMWAVE_CLUSTER_ID = 0xFC32
         translation_key="mmwave_detect_sensitivity",
         fallback_name="mmWave detect sensitivity",
     )
+  .number(
+        "mmwave_stay_life",
+        MMWAVE_CLUSTER_ID,
+        min_value=0,
+        max_value=4294967295,
+        step=1,
+        entity_type=EntityType.CONFIG,
+        translation_key="mmwave_stay_life",
+        fallback_name="mmWave stay life",
+    )
     .number(
         "mmwave_detect_trigger",
         MMWAVE_CLUSTER_ID,


### PR DESCRIPTION
## Proposed change
I realized stay life was missing, so I've added an entity for it.


## Additional information
Note: the following entities in the Inovelli VZM32-SN custom cluster are also missing. We may want to add these as well?

- active_power_reports
- periodic_power_and_energy_reports
- active_energy_reports
- switch_type
- leading_or_trailing_edge
- device_bind_number
- default_led#_strip_[color|intensity]_when_[on|off]
- fan_single_tap_behavior
- fan_timer_display
- fan_module_binding_control
- low_for_bound_control
- [high|medium|low|led_color]_for_bound_control

## Device diagnostics
<!--
  Diagnostics data is used by ZHA unit tests to make sure quirks create the expected
  entities and we do not have regressions. For all new quirks, we require device
  diagnostics.

  You can find the diagnostics information by going to the device page, clicking the
  three dots, and then by clicking on "Download diagnostics". Drag-and-drop the
  downloaded file into this section.
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [X] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
- [ ] Device diagnostics data has been attached
